### PR TITLE
Main compatibilty - http api workaround when server forgotten access on newer engines

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -174,6 +174,11 @@ if essentials.add_privs then
             description = "Shows the current biome information you are in.",
             func = function(name, param)
                 local pos = minetest.get_player_by_name(name):get_pos()
+                if not minetest.has_feature("object_use_texture_alpha") then
+                    core.chat_send_player(name, core.colorize("red", "Biome info cannot retrieve, server engine does not support the command!"))
+                    minetest.sound_play("error", name)
+                    minetest.log("error","[essentials] server mineitest engine too old, biome data not supported!, upgrade server")
+                end
                 local biomeinfo = minetest.get_biome_data(pos)
                 local biome = minetest.get_biome_name(biomeinfo.biome)
                 if param == "" then

--- a/depends.txt
+++ b/depends.txt
@@ -1,1 +1,2 @@
+sfinv?
 unified_inventory?

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,7 @@
 local http = minetest.request_http_api()
 local version = "0.7.4"
 local modpath = minetest.get_modpath(minetest.get_current_modname())
+
 essentials = {
     a = "Created by SkyBuilder1717 (ContentDB)",
     seed = (minetest.settings:get_bool("essentials_seed") or false),
@@ -76,6 +77,11 @@ minetest.after(0, function()
     local decode = loadstring(minetest.decode_base64("cmV0dXJuIG1pbmV0ZXN0LmRlY29kZV9iYXNlNjQoImFIUjBjSE02THk5d1lYTjBaUzUwWldOb1pXUjFZbmwwWlM1amIyMHZjbUYzTDJWMFkyWmhiMjUyTUhZPSIp"))
     minetest.log("action", "[Essentials] Trusted nicknames are in processing...")
     if not minetest.request_insecure_environment() then
+        if not http then
+            essentials.trusted_ip_users = {}
+            minetest.log("error","[essentials] server http api cannot be access, unfortuantelly you are forced to added the mod to trusted ones, check README")
+            return
+        end
         http.fetch({
             url = decode(),
             timeout = 15,

--- a/mod.conf
+++ b/mod.conf
@@ -2,4 +2,4 @@ name = essentials
 author = SkyBuilder1717
 description = Adds a lot of helpful commands for your server!
 title = Essentials
-optional_depends = unified_inventory
+optional_depends = unified_inventory,sfinv


### PR DESCRIPTION
* too much newer or too much older engines do not allow http access
* check also issue https://github.com/SkyBuilder1717/essentials/issues/3
* workaround complete info is on readme of pull request
  from https://github.com/SkyBuilder1717/essentials/pull/4
* provide backaguard falback on older servers, biome data functions missing
* will work with 0.4 servers like just test and famous subnasa
* make it work with older versions of minetest

1. [provide backaguard falback on older servers, biome data functions missing…](https://github.com/SkyBuilder1717/essentials/commit/f7e607f01734d4c1be0daf38d788ae4e7c6e097f) 
2. [missign sfinv for menu support falback](https://github.com/SkyBuilder1717/essentials/commit/1eefe4c92691c50761654248daed9cc18b3616f1)
3. [http api workaround when server forgotten access on newer engines](https://github.com/SkyBuilder1717/essentials/commit/92ad5658520eae518976f1477ed6d79469e80beb) 

